### PR TITLE
Support specifying a Docker Hub username

### DIFF
--- a/.github/workflows/automated-build.yaml
+++ b/.github/workflows/automated-build.yaml
@@ -1,10 +1,15 @@
-# Note: this workflow assumes that your github user name = your Docker Hub user name.
+# Note: by default this workflow assumes that your github user name = your Docker Hub user name.
+# You can force it using `with: {DOCKER_HUB_USERNAME: myuser}` in the calling workflow
 # It will also probably break for GitHub users or repositories with uppercase letters.
 
 name: Automated Build
 
 on:
   workflow_call:
+    inputs:
+      DOCKER_HUB_USERNAME:
+        required: false
+        type: string
     secrets:
       DOCKER_HUB_TOKEN:
         required: false
@@ -30,6 +35,11 @@ jobs:
           if [ "${{ secrets.DOCKER_HUB_TOKEN }}" ]; then
             echo PUSH_TO_DOCKER_HUB=yes >> $GITHUB_ENV
             IMAGES="$IMAGES docker.io/${{ github.repository }}"
+            if [ "${{ inputs.DOCKER_HUB_USERNAME}}" ]; then
+              echo DOCKER_HUB_USERNAME="${{ inputs.DOCKER_HUB_USERNAME }}" >> $GITHUB_ENV
+            else
+              echo DOCKER_HUB_USERNAME="${{ github.repository_owner }}" >> $GITHUB_ENV
+            fi
           fi
           if true; then
             echo PUSH_TO_GHCR=yes >> $GITHUB_ENV
@@ -49,7 +59,7 @@ jobs:
         if: env.PUSH_TO_DOCKER_HUB
         uses: docker/login-action@v2
         with:
-          username: ${{ github.repository_owner }}
+          username: ${{ env.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       -

--- a/.github/workflows/automated-build.yaml
+++ b/.github/workflows/automated-build.yaml
@@ -35,7 +35,7 @@ jobs:
           if [ "${{ secrets.DOCKER_HUB_TOKEN }}" ]; then
             echo PUSH_TO_DOCKER_HUB=yes >> $GITHUB_ENV
             IMAGES="$IMAGES docker.io/${{ github.repository }}"
-            if [ "${{ inputs.DOCKER_HUB_USERNAME}}" ]; then
+            if [ "${{ inputs.DOCKER_HUB_USERNAME }}" ]; then
               echo DOCKER_HUB_USERNAME="${{ inputs.DOCKER_HUB_USERNAME }}" >> $GITHUB_ENV
             else
               echo DOCKER_HUB_USERNAME="${{ github.repository_owner }}" >> $GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Note that this is very opinionated.
 - It always pushes the resulting images to GHCR.
 - If the GitHub repo is named `foo/bar`, the image on GHCR will be `ghcr.io/foo/bar`.
 - If your GitHub repo has a `DOCKER_HUB_TOKEN` secret, it will push the resulting images to the Docker Hub as well.
+- By default, it uses the Github repo owner as the Docker Hub username, but you can force it using the `DOCKER_HUB_USERNAME` input.
 - When pushing to the Docker Hub, it pushes to `foo/bar` (aka `docker.io/foo/bar`).
 
 Future features might include:
@@ -44,6 +45,8 @@ jobs:
     uses: jpetazzo/workflows/.github/workflows/automated-build.yaml@main
     #secrets:
     #  DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
+    #with:
+    #  DOCKER_HUB_USERNAME: myuser
 EOF
 ```
 
@@ -53,7 +56,7 @@ If you want the images to be pushed to the Docker Hub:
 
 1. Go get a Docker Hub token
 2. Add the token to your repository (https://github.com/{user}/{repo}/settings/secrets/actions/new)
-3. Uncomment the `secrets:` section in your workflow file above, commit, push
+3. Uncomment the `secrets:` section (and possibly the `with:` section) in your workflow file above, commit, push
 
 ## Images using this workflow
 


### PR DESCRIPTION
This is useful when pushing images from an organization Github repository to an organization Docker Hub image, since Docker Hub tokens are linked to a personal account.