### PR TITLE
Allow calling workflow to choose platforms to build against

### DIFF
--- a/.github/workflows/automated-build.yaml
+++ b/.github/workflows/automated-build.yaml
@@ -10,6 +10,10 @@ on:
       DOCKER_HUB_USERNAME:
         required: false
         type: string
+      PLATFORMS:
+        required: false
+        type: string
+        default: 'linux/amd64,linux/arm64,linux/arm/v7'
     secrets:
       DOCKER_HUB_TOKEN:
         required: false
@@ -83,6 +87,6 @@ jobs:
       -
         uses: docker/build-push-action@v3
         with:
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: ${{ inputs.PLATFORMS }}
           push: true
           tags: ${{ env.IMAGES }}


### PR DESCRIPTION
Useful when we need to build against 32 bits Linux.